### PR TITLE
Fix rg useage

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -18,16 +18,20 @@ local function entry(_, args)
 	local cwd = state()
 	local shell_value = os.getenv("SHELL"):match(".*/(.*)")
 	local cmd_args = ""
+
+	local preview_cmd = [===[line={2} && begin=$( if [[ $line -lt 7 ]]; then echo $((line-1)); else echo 6; fi ) && bat --highlight-line={2} --color=always --line-range $((line-begin)):$((line+10)) {1}]===]
+	if shell_value == "fish" then
+		preview_cmd = [[set line {2} && set begin ( test $line -lt 7  &&  echo (math "$line-1") || echo  6 ) && bat --highlight-line={2} --color=always --line-range (math "$line-$begin"):(math "$line+10") {1}]]
+	elseif shell_value == "nu" then
+		preview_cmd = [[let line = ({2} | into int); let begin = if $line < 7 { $line - 1 } else { 6 }; bat --highlight-line={2} --color=always --line-range $'($line - $begin):($line + 10)' {1}]]
+	end
+
 	if args[1] == "fzf" then
 		cmd_args = [[fzf --preview='bat --color=always {1}']]
-	elseif shell_value == "fish" then
-		cmd_args = [[rg ./ --line-number | fzf --preview='set line {2} && set begin ( test $line -lt 7  &&  echo (math "$line-1") || echo  6 ) && bat --highlight-line={2} --color=always --line-range (math "$line-$begin"):(math "$line+10") {1}' --delimiter=':' --preview-window up:60% --nth '3..']]
-	elseif shell_value == "nu" then
-		cmd_args = "rg . --line-number | fzf --preview='let line = ({2} | into int); let begin = if $line < 7 { $line - 1 } else { 6 }; bat --highlight-line={2} --color=always --line-range $'($line - $begin):($line + 10)' {1}' --delimiter=':' --preview-window up:60% --nth '3..'"
 	else
-		cmd_args = "rg ./ --line-number | fzf --preview='line={2} && begin=$( if [[ $line -lt 7 ]]; then echo $((line-1)); else echo 6; fi ) && bat --highlight-line={2} --color=always --line-range $((line-begin)):$((line+10)) {1}' --delimiter=':' --preview-window up:60% --nth '3..'"
+		cmd_args = [[rg --color=always --line-number --no-heading --smart-case '' | fzf --ansi --preview=']] .. preview_cmd .. [[' --delimiter=':' --preview-window='up:60%' --nth='3..']]
 	end
-	
+
 	local child, err =
 		Command(shell_value):args({"-c", cmd_args}):cwd(cwd):stdin(Command.INHERIT):stdout(Command.PIPED):stderr(Command.INHERIT):spawn()
 


### PR DESCRIPTION
It looks like `rg ./ --line-number` will search "./" as regexp. New paramters are from [fzf's doc](https://github.com/junegunn/fzf/blob/master/ADVANCED.md#using-fzf-as-the-secondary-filter).