### PR TITLE
Add args to search by ripgrep

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Yazi plugin for rg search with fzf file preview
 
 > [!NOTE]
 > The latest main branch of Yazi is required at the moment.
-> 
+>
 > Support shell: `bash`, `zsh` ,`fish` ,`nushell`
 
 ## Dependcy
@@ -29,6 +29,13 @@ git clone https://github.com/DreamMaoMao/fg.yazi.git ~/.config/yazi/plugins/fg.y
 on   = [ "f","g" ]
 run  = "plugin fg"
 desc = "find file by content"
+```
+
+```toml
+[[manager.prepend_keymap]]
+on   = [ "f","G" ]
+run  = "plugin fg --args='rg'"
+desc = "find file by content using ripgrep"
 ```
 
 ```toml

--- a/init.lua
+++ b/init.lua
@@ -28,6 +28,17 @@ local function entry(_, args)
 
 	if args[1] == "fzf" then
 		cmd_args = [[fzf --preview='bat --color=always {1}']]
+	elseif args[1] == "rg" then
+		cmd_args = [[
+			RG_PREFIX="rg --column --line-number --no-heading --color=always --smart-case "
+			fzf --ansi --disabled \
+				--bind "start:reload:$RG_PREFIX {q}" \
+				--bind "change:reload:sleep 0.1; $RG_PREFIX {q} || true" \
+				--delimiter : \
+				--preview ']] .. preview_cmd .. [[' \
+				--preview-window 'up,60%' \
+				--nth '3..'
+		]]
 	else
 		cmd_args = [[rg --color=always --line-number --no-heading --smart-case '' | fzf --ansi --preview=']] .. preview_cmd .. [[' --delimiter=':' --preview-window='up:60%' --nth='3..']]
 	end


### PR DESCRIPTION
Add an argument `rg` to make the searching and filtering done by ripgrep. It will lose the "fuzziness", but provide better performance on larger projects.